### PR TITLE
Recommended startup script clean up and update

### DIFF
--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -1,9 +1,5 @@
-module reset
-module load slurm
-module load git/2.8.0-foss-2016a
-
 # Directory change
-function experimental_pipelines(){
+function experimental_pipelines() {
     if [ "$#" -ne 1 ]; then
         echo "Usage:"
         echo "experimemtal_pipeline directory_name"
@@ -18,29 +14,19 @@ alias exp_pipes=experimental_pipelines
 alias scratch="cd $USER_SCRATCH"
 
 # codicem
-function load_codicem(){
+function load_codicem() {
     conda activate codicem_env
     cd /data/project/worthey_lab/tools/codicem/codicem-provision/sample-loader/cluster
 }
 
 alias codicem=load_codicem
 
-# congenica
-function load_congenica(){
-    module reset
-    module load Python/2.7.13-foss-2016b
-    source /data/project/worthey_lab/tools/sapientia-client-2.3.0.3/congenica/bin/activate  # commented out by conda initialize
-    sapientia test
-}
-
-alias congenica=load_congenica
-
 # pipeline
-function status_smvp(){
+function status_smvp() {
     find "$SMVP_LOGS_DIR" -maxdepth 1 -name "*.err" -mtime -$1 -print0 | xargs -0 /data/project/worthey_lab/tools/pipeline-status-scripts/pretty_status_snakemake_pipeline.sh
 }
 
-function status_svp(){
+function status_svp() {
     find "$SVP_LOGS_DIR" -maxdepth 1 -name "*.err" -mtime -$1 -print0 | xargs -0 /data/project/worthey_lab/tools/pipeline-status-scripts/pretty_status_snakemake_pipeline.sh
 }
 
@@ -64,7 +50,7 @@ srun_custom() {
     fi
 }
 
-function better_format_sacct(){
+function better_format_sacct() {
     sacct --format="JobID,JobName,Ntasks,MaxRSS,Elapsed,state,NodeList,ReqMem,MaxVMSize,AveVMSize,Partition,AllocTRES%40" --units=M "$@"
 }
 
@@ -74,7 +60,7 @@ alias srun_medium="srun --ntasks=1 --cpus-per-task=4 --mem-per-cpu=4096 --partit
 alias SC=better_format_sacct
 
 alias SQ='squeue -o "%.8i %.20j %.10P %.7u %.5D %.4C %.11M  %.11l %.3t %.11m %R" -u $USER'
-alias SQ_long='squeue -o "%.8i %.20j %.10P %.7u %.5D %.11M  %.11l %.3t %.11m %R %V %o" -u $USER' 
+alias SQ_long='squeue -o "%.8i %.20j %.10P %.7u %.5D %.11M  %.11l %.3t %.11m %R %V %o" -u $USER'
 alias njobs="SQ -h | wc -l"
 alias scontr='scontrol show job -d'
 alias SR='sstat --format="JobID,NTasks,AveCPU,AvePages,AveRSS,AveVMSize,MaxRSSNode" --allsteps'

--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -65,8 +65,16 @@ function recall_dir() {
         echo "Error: can't run GPFS file recall on login node. File recall to GPFS should only be run on compute nodes."
         echo "Solution: Consider starting an interactive job and running this command there."
     else
-        module load parallel
-        find "$(realpath $1)" -type f -print0 | parallel --null -j ${SLURM_CPUS_ON_NODE} -n10 head -c1 {} > /dev/null
+        local DIR2RECALL="$(realpath $1)"
+        # `du` returns zero blocks used on disk (GPFS in this case) for files that are on CEPH
+        local RECALL_FILE_CNT=$(find "${DIR2RECALL}" -type f -exec du {} + | awk 'BEGIN{cntr=0} {if($1 == 0){cntr=cntr+1}} END{print cntr}')
+        if [ ${RECALL_FILE_CNT} -gt 0 ]; then
+            echo "Recalling ${RECALL_FILE_CNT} files to GPFS..."
+            module load parallel
+            find "${DIR2RECALL}" -type f -exec du {} + | awk '($1 == 0){print $2}' | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
+        else
+            echo "All files in ${DIR2RECALL} are already in GPFS, nothing needs to be done."
+        fi
     fi
 }
 
@@ -77,9 +85,14 @@ function recall_git() {
         echo "Error: can't run git repo file recall on login node. File recall to GPFS should only be run on compute nodes."
         echo "Solution: Consider starting an interactive job and running this command there."
     else
-        module load parallel
-        git ls-files | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} > /dev/null
+        # `du` returns zero blocks used on disk (GPFS in this case) for files that are on CEPH
+        local RECALL_FILE_CNT=$(git ls-files | xargs du | awk 'BEGIN{cntr=0} {if($1 == 0){cntr=cntr+1}} END{print cntr}')
+        if [ ${RECALL_FILE_CNT} -gt 0 ]; then
+            echo "Recalling ${RECALL_FILE_CNT} files to GPFS..."
+            module load parallel
+            git ls-files | xargs du | awk '($1 == 0){print $2}' | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
+        else
+            echo "All tracked files in $(git rev-parse --show-toplevel) are already in GPFS, nothing needs to be done."
+        fi
     fi
 }
-
-

--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -77,6 +77,7 @@ function recall_git() {
         echo "Error: can't run git repo file recall on login node. File recall to GPFS should only be run on compute nodes."
         echo "Solution: Consider starting an interactive job and running this command there."
     else
+        module load parallel
         git ls-files -m | parallel -j ${SLURM_NTASKS} head -c1 {} > /dev/null
     fi
 }

--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -66,7 +66,7 @@ function recall_dir() {
         echo "Solution: Consider starting an interactive job and running this command there."
     else
         module load parallel
-        find "$(realpath $1)" -type f -print0 | parallel --null -j ${SLURM_NTASKS} -n10 head -c1 {} > /dev/null
+        find "$(realpath $1)" -type f -print0 | parallel --null -j ${SLURM_CPUS_ON_NODE} -n10 head -c1 {} > /dev/null
     fi
 }
 
@@ -78,7 +78,7 @@ function recall_git() {
         echo "Solution: Consider starting an interactive job and running this command there."
     else
         module load parallel
-        git ls-files -m | parallel -j ${SLURM_NTASKS} head -c1 {} > /dev/null
+        git ls-files | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} > /dev/null
     fi
 }
 

--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -13,14 +13,6 @@ alias worthey_lab="cd /data/project/worthey_lab"
 alias exp_pipes=experimental_pipelines
 alias scratch="cd $USER_SCRATCH"
 
-# codicem
-function load_codicem() {
-    conda activate codicem_env
-    cd /data/project/worthey_lab/tools/codicem/codicem-provision/sample-loader/cluster
-}
-
-alias codicem=load_codicem
-
 # pipeline
 function status_smvp() {
     find "$SMVP_LOGS_DIR" -maxdepth 1 -name "*.err" -mtime -$1 -print0 | xargs -0 /data/project/worthey_lab/tools/pipeline-status-scripts/pretty_status_snakemake_pipeline.sh
@@ -30,10 +22,8 @@ function status_svp() {
     find "$SVP_LOGS_DIR" -maxdepth 1 -name "*.err" -mtime -$1 -print0 | xargs -0 /data/project/worthey_lab/tools/pipeline-status-scripts/pretty_status_snakemake_pipeline.sh
 }
 
-SMVP_LOGS_DIR="/data/project/worthey_lab/projects/production_pipelines/logs/small_variant_caller_pipeline/"
-SVP_LOGS_DIR="/data/project/worthey_lab/projects/production_pipelines/logs/manta_sv_caller_pipeline/"
-export SMVP_LOGS_DIR
-export SVP_LOGS_DIR
+export SMVP_LOGS_DIR="/data/project/worthey_lab/projects/production_pipelines/logs/small_variant_caller_pipeline/"
+export SVP_LOGS_DIR="/data/project/worthey_lab/projects/production_pipelines/logs/manta_sv_caller_pipeline/"
 
 alias smvp_logs="cd $SMVP_LOGS_DIR"
 alias svp_logs="cd $SVP_LOGS_DIR"
@@ -64,3 +54,31 @@ alias SQ_long='squeue -o "%.8i %.20j %.10P %.7u %.5D %.11M  %.11l %.3t %.11m %R 
 alias njobs="SQ -h | wc -l"
 alias scontr='scontrol show job -d'
 alias SR='sstat --format="JobID,NTasks,AveCPU,AvePages,AveRSS,AveVMSize,MaxRSSNode" --allsteps'
+
+# GPFS
+# recall all files in a directory to GPFS (from CEPH)
+function recall_dir() {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage:"
+        echo "recall_dir <dir-path>"
+    elif [ ! -n "${SLURM_JOB_ID+x}" ]; then
+        echo "Error: can't run GPFS file recall on login node. File recall to GPFS should only be run on compute nodes."
+        echo "Solution: Consider starting an interactive job and running this command there."
+    else
+        module load parallel
+        find "$(realpath $1)" -type f -print0 | parallel --null -j ${SLURM_NTASKS} -n10 head -c1 {} > /dev/null
+    fi
+}
+
+# recall all tracked files in a git repo so git doesn't think tons of changes happened
+# assumes the current working directory is part of the git repo being recalled
+function recall_git() {
+    if [ ! -n "${SLURM_JOB_ID+x}" ]; then
+        echo "Error: can't run git repo file recall on login node. File recall to GPFS should only be run on compute nodes."
+        echo "Solution: Consider starting an interactive job and running this command there."
+    else
+        git ls-files -m | parallel -j ${SLURM_NTASKS} head -c1 {} > /dev/null
+    fi
+}
+
+

--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -81,24 +81,13 @@ function gen_file_recall() {
 
         # remove true empty files from list of files with zero disk usage to make a list of files
         # that actually need to be recalled
-        for element_to_remove in "${TRUE_EMPTY_FILES[@]}"; do
-            # Iterate over indices of NO_SIZE_FILES to find the matching element
-            for i in "${!NO_SIZE_FILES[@]}"; do
-                if [[ "${NO_SIZE_FILES[$i]}" == "$element_to_remove" ]]; then
-                    # Unset (remove) the matching element from NO_SIZE_FILES
-                    unset 'NO_SIZE_FILES[i]'
-                fi
-            done
-        done
+        mapfile -t RECALL_FILES < <(comm -23 <(printf "%s\n" "${NO_SIZE_FILES[@]}" | sort) <(printf "%s\n" "${TRUE_EMPTY_FILES[@]}" | sort))
 
-        # Re-index the array after removal
-        NO_SIZE_FILES=("${NO_SIZE_FILES[@]}")
-
-        local RECALL_FILE_CNT=${#NO_SIZE_FILES[@]}
+        local RECALL_FILE_CNT=${#RECALL_FILES[@]}
         if [ ${RECALL_FILE_CNT} -gt 0 ]; then
             echo "Recalling ${RECALL_FILE_CNT} files to GPFS..."
             module load parallel
-            printf "%s\n" "${NO_SIZE_FILES[@]}" | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
+            printf "%s\n" "${RECALL_FILES[@]}" | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
         else
             echo "Requested files in ${DIR2RECALL} are already in GPFS, nothing needs to be done."
         fi

--- a/startup_scripts/.recommended_startup_commands
+++ b/startup_scripts/.recommended_startup_commands
@@ -56,43 +56,67 @@ alias scontr='scontrol show job -d'
 alias SR='sstat --format="JobID,NTasks,AveCPU,AvePages,AveRSS,AveVMSize,MaxRSSNode" --allsteps'
 
 # GPFS
+# general file recall function
+function gen_file_recall() {
+    if [ ! -n "${SLURM_JOB_ID+x}" ]; then
+        echo "Error: can't run GPFS file recall on login node. File recall to GPFS should only be run on compute nodes."
+        echo "Solution: Consider starting an interactive job and running this command there."
+    else
+        local DIR2RECALL="$(realpath $1)"
+        local LISTING_METHOD="$2"
+
+        if [[ "${LISTING_METHOD}" == "git" ]]; then
+            # get list of files that are truly empty files (eg. .gitkeep) tracked by the repo
+            mapfile -t TRUE_EMPTY_FILES < <(git ls-files | xargs du --apparent-size | awk '($1 == 0){print $2}')
+
+            # get list of files that `du` returns zero blocks used on disk (GPFS in this case) for files that are on CEPH
+            mapfile -t NO_SIZE_FILES < <(git ls-files | xargs du | awk '($1 == 0){print $2}')
+        else
+            # get list of files that are truly empty files (eg. .gitkeep) tracked by the repo
+            mapfile -t TRUE_EMPTY_FILES < <(find "${DIR2RECALL}" -type f -exec du --apparent-size {} + | awk '($1 == 0){print $2}')
+
+            # get list of files that `du` returns zero blocks used on disk (GPFS in this case) for files that are on CEPH
+            mapfile -t NO_SIZE_FILES < <(find "${DIR2RECALL}" -type f -exec du {} + | awk '($1 == 0){print $2}')
+        fi
+
+        # remove true empty files from list of files with zero disk usage to make a list of files
+        # that actually need to be recalled
+        for element_to_remove in "${TRUE_EMPTY_FILES[@]}"; do
+            # Iterate over indices of NO_SIZE_FILES to find the matching element
+            for i in "${!NO_SIZE_FILES[@]}"; do
+                if [[ "${NO_SIZE_FILES[$i]}" == "$element_to_remove" ]]; then
+                    # Unset (remove) the matching element from NO_SIZE_FILES
+                    unset 'NO_SIZE_FILES[i]'
+                fi
+            done
+        done
+
+        # Re-index the array after removal
+        NO_SIZE_FILES=("${NO_SIZE_FILES[@]}")
+
+        local RECALL_FILE_CNT=${#NO_SIZE_FILES[@]}
+        if [ ${RECALL_FILE_CNT} -gt 0 ]; then
+            echo "Recalling ${RECALL_FILE_CNT} files to GPFS..."
+            module load parallel
+            printf "%s\n" "${NO_SIZE_FILES[@]}" | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
+        else
+            echo "Requested files in ${DIR2RECALL} are already in GPFS, nothing needs to be done."
+        fi
+    fi
+}
+
 # recall all files in a directory to GPFS (from CEPH)
 function recall_dir() {
     if [ "$#" -ne 1 ]; then
         echo "Usage:"
         echo "recall_dir <dir-path>"
-    elif [ ! -n "${SLURM_JOB_ID+x}" ]; then
-        echo "Error: can't run GPFS file recall on login node. File recall to GPFS should only be run on compute nodes."
-        echo "Solution: Consider starting an interactive job and running this command there."
     else
-        local DIR2RECALL="$(realpath $1)"
-        # `du` returns zero blocks used on disk (GPFS in this case) for files that are on CEPH
-        local RECALL_FILE_CNT=$(find "${DIR2RECALL}" -type f -exec du {} + | awk 'BEGIN{cntr=0} {if($1 == 0){cntr=cntr+1}} END{print cntr}')
-        if [ ${RECALL_FILE_CNT} -gt 0 ]; then
-            echo "Recalling ${RECALL_FILE_CNT} files to GPFS..."
-            module load parallel
-            find "${DIR2RECALL}" -type f -exec du {} + | awk '($1 == 0){print $2}' | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
-        else
-            echo "All files in ${DIR2RECALL} are already in GPFS, nothing needs to be done."
-        fi
+        gen_file_recall "$(realpath $1)" "dir"
     fi
 }
 
 # recall all tracked files in a git repo so git doesn't think tons of changes happened
 # assumes the current working directory is part of the git repo being recalled
 function recall_git() {
-    if [ ! -n "${SLURM_JOB_ID+x}" ]; then
-        echo "Error: can't run git repo file recall on login node. File recall to GPFS should only be run on compute nodes."
-        echo "Solution: Consider starting an interactive job and running this command there."
-    else
-        # `du` returns zero blocks used on disk (GPFS in this case) for files that are on CEPH
-        local RECALL_FILE_CNT=$(git ls-files | xargs du | awk 'BEGIN{cntr=0} {if($1 == 0){cntr=cntr+1}} END{print cntr}')
-        if [ ${RECALL_FILE_CNT} -gt 0 ]; then
-            echo "Recalling ${RECALL_FILE_CNT} files to GPFS..."
-            module load parallel
-            git ls-files | xargs du | awk '($1 == 0){print $2}' | parallel -j ${SLURM_CPUS_ON_NODE} head -c1 {} >/dev/null
-        else
-            echo "All tracked files in $(git rev-parse --show-toplevel) are already in GPFS, nothing needs to be done."
-        fi
-    fi
+    gen_file_recall "$(git rev-parse --show-toplevel)" "git"
 }

--- a/startup_scripts/README.md
+++ b/startup_scripts/README.md
@@ -1,25 +1,33 @@
 # Common Startup Scripts
+
 Scripts to create shared bash and zsh commands for Cheaha.
 
 ## Scripts
+
 ### `.recommended_startup_commands`
-A script with all recommended commands based on commonly used pipelines, directories, and tools. 
+
+A script with all recommended commands based on commonly used pipelines, directories, and tools.
+
 #### **How to use**
+
 Locate `.bashrc` and `.zshrc` in the `$HOME` directory and add the following lines:
+
 ```bash
 if [ -f "/data/project/worthey_lab/tools/learnings_journal/startup_scripts/.recommended_startup_commands"]; then
     . "/data/project/worthey_lab/tools/learnings_journal/startup_scripts/.recommended_startup_commands"
 fi
 ```
+
 #### **commands**
+
 | Command                                | Purpose                                                                                                                             |
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | projects                               | Change directory to the projects directory (`/data/project/worthey_lab/projects`)                                                   |
 | worthey_lab                            | Change directory to the lab space (`/data/project/worthey_lab`)                                                                     |
-| exp_pipes \<directory_name\> | Change directory to experimental pipelines directory (`/data/project/worthey_lab/projects/experimental_pipelines/<directory_name>`) |
+| exp_pipes \<directory_name\>           | Change directory to experimental pipelines directory (`/data/project/worthey_lab/projects/experimental_pipelines/<directory_name>`) |
 | scratch                                | Change directory to user scratch directory                                                                                          |
-| codicem                                | Load codicem                                                                                                                        |
-| congenica                              | Load congenica                                                                                                                      |
+| recall_dir \<directory\>               | recall all files in a directory to GPFS (from CEPH)                                                                                 |
+| recall_git                             | recall all tracked files in a git repo                                                                                              |
 | smvp_logs                              | Change directory to logs for small variant caller pipeline                                                                          |
 | smvp_stat n                            | Get status of jobs running small variant caller pipeline                                                                            |
 | svp_logs                               | Change directory to logs for manta sv caller pipeline                                                                               |
@@ -31,20 +39,25 @@ fi
 | SQ                                     | Well formatted squeue                                                                                                               |
 | SQ_long                                | Well formatted squeue with submission time and command ran info                                                                     |
 | njobs                                  | Number of jobs running                                                                                                              |
-| scontr jobid                           | Information for a particular job (*Note: This alias only works for currently running jobs and not for completed/pending jobs*)                                                                                                    |
-| SR jobid                               | Status information for a job (*Note: This alias only works for currently running jobs and not for completed/pending jobs*)                                                                                                       |
-
+| scontr jobid                           | Information for a particular job (*Note: This alias only works for currently running jobs and not for completed/pending jobs*)      |
+| SR jobid                               | Status information for a job (*Note: This alias only works for currently running jobs and not for completed/pending jobs*)          |
 
 ### `.helpful_startup_commands`
+
 This script contains optional commands that are useful.
+
 #### **How to use**
+
 Locate `.bashrc` and `.zshrc` in `$HOME` and add the following lines:
+
 ```bash
 if [ -f "/data/project/worthey_lab/tools/learnings_journal/startup_scripts/.helpful_startup_commands"]; then
     . "/data/project/worthey_lab/tools/learnings_journal/startup_scripts/.helpful_startup_commands"
 fi
-``` 
+```
+
 #### **commands**
+
 | Command               | Purpose                                                                                            |
 |-----------------------|----------------------------------------------------------------------------------------------------|
 | rmi file              | Interactive remove                                                                                 |


### PR DESCRIPTION
The following changes were made to the `recommended startup commands` startup script:

1. Removal of out-dated module loading at the start of the script
2. Some minor formatting clean up
3. Addition of 2 functions to aid with recalling files to GPFS after the switch to Cheaha's storage model

Reviewer should review the testing of the 2 new functions below.
`recall_dir` function testing:
<img width="1800" height="304" alt="image" src="https://github.com/user-attachments/assets/8629540c-df05-40ca-8f73-3deb5d9a2df9" />
`recall_git` function testing:
<img width="1791" height="224" alt="image" src="https://github.com/user-attachments/assets/11d8882b-4d23-49c1-98c3-aa84a1d09615" />

New functions can be tested by checking out the `startup-scripts` branch on Cheaha and sourcing the `startup_scripts/.recommended_startup_commands` file and then running the commands.