### PR TITLE
Added scripts to run R Studio and VS code container on CHEAHA and tunnel to local + recipes for containers

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -7,7 +7,7 @@ Short overview and quick steps for running RStudio Server and VS Code Server on 
 - Runs on compute nodes (not login nodes)
 - Mounts your home, data, and project directories
 - Persistent settings between sessions
-- Pre-built containers live at:
+- Pre-built container images live at:
 ```
 /data/project/worthey_lab/containers_temp
 ```

--- a/containers/README.md
+++ b/containers/README.md
@@ -58,7 +58,7 @@ Open: http://localhost:8769
 - CHEAHA uses Singularity to run containers
 - Apptainer is only needed locally if you want to build custom containers
 - RStudio build details: see [containers/rstudio/README.md](containers/rstudio/README.md)
-- VS Code build README will be added later
+- VS Code build details: see [containers/vscode/README.md](containers/vscode/README.md)
 
 ## Mounts (Quick)
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,159 @@
+# Running RStudio & VS Code on CHEAHA
+
+Instructions for running RStudio Server and VS Code Server on CHEAHA using Singularity containers.
+
+## What You Get
+
+- RStudio and VS Code running on compute nodes (not login nodes)
+- Access to your home directory, data storage, and lab projects
+- Persistent configurations and R libraries between sessions
+
+## Prerequisites
+
+- CHEAHA account with SSH access
+- SSH key configured for tunneling from your local machine
+
+## Quick Start
+
+### 1. Get the Container Images
+
+Pre-built containers are available at:
+```
+/data/project/worthey_lab/containers_temp
+```
+
+Or build your own using Apptainer (locally) and transfer to CHEAHA:
+```bash
+# On your local machine (with Apptainer installed)
+apptainer build rstudio_custom.sif rstudio.def
+
+# Transfer to CHEAHA
+scp rstudio_custom.sif your_username@cheaha.rc.uab.edu:~/
+```
+
+**Note:** CHEAHA has Singularity for running containers. Apptainer is only needed locally if you want to build custom containers from `.def` files or pull from Docker.
+
+### 2. Set Up Directories (One-Time)
+
+```bash
+mkdir -p ~/portable_rstudio_dirs/{etc/rstudio,home,run,tmp,var-lib,secure}
+mkdir -p ~/code-server-base/{.config,.cache,home,run,tmp}
+mkdir -p ~/singularity_sessions_slurm/logs
+chmod 700 ~/portable_rstudio_dirs/secure
+```
+
+### 3. Submit the Job
+
+```bash
+sbatch rstudio/run_rstudio_slurm.sh
+# or
+sbatch vscode/run_code_server_slurm.sh
+```
+
+Check which compute node it's running on:
+```bash
+squeue -u $USER
+```
+Note the node name (e.g., `c0167`).
+
+### 4. Create SSH Tunnel (From Your Local Machine)
+
+```bash
+# For VS Code (port 8769)
+ssh -N -L 127.0.0.1:8769:127.0.0.1:8769 -J your_username@cheaha.rc.uab.edu your_username@c0167
+
+# For RStudio (port 8799)
+ssh -N -L 127.0.0.1:8799:127.0.0.1:8799 -J your_username@cheaha.rc.uab.edu your_username@c0167
+```
+
+Replace:
+- `your_username` with your CHEAHA username
+- `c0167` with the compute node from step 3
+
+Keep this terminal open.
+
+### 5. Open in Browser
+
+- **VS Code**: http://localhost:8769
+- **RStudio**: http://localhost:8799
+
+## What Gets Mounted
+
+### RStudio
+
+Inside RStudio, you'll find:
+- `~/cheaha_home` - your CHEAHA home directory
+- `~/cheaha_data` - your `/data/user/$USER` directory  
+- `~/nf1_rat_lw` - NF1 Rat Cohort project data
+
+### VS Code
+
+- `/mnt/cheaha_home` - your CHEAHA home directory
+- `/mnt/cheaha_data` - your `/data/user/$USER` directory
+- `/mnt/nf1_rat_lw` - NF1 Rat Cohort project data
+
+## Job Settings
+
+### RStudio
+- 8 CPUs, 32 GB RAM
+- 150 hours max runtime
+- Port 8799
+
+### VS Code  
+- 8 CPUs, 32 GB RAM
+- 8 hours max runtime
+- Port 8769
+
+Edit the SBATCH directives in the job scripts to change these.
+
+## Adding More Mounts
+
+Edit the `--bind` lines in your job script:
+
+```bash
+--bind "/data/project/worthey_lab/projects/your_project:/home/$USER/my_project"
+```
+
+## R Packages
+
+R packages install to a persistent location automatically:
+
+```r
+install.packages("ggplot2")
+.libPaths()  # check where packages are stored
+```
+
+## Tools Included
+
+- samtools, bcftools, bedtools
+- CNVkit (in VS Code container via Micromamba)
+- HDF5, Arrow libraries
+- Standard compression tools
+
+## Managing Jobs
+
+```bash
+# Check running jobs
+squeue -u $USER
+
+# Cancel a job
+scancel <JOB_ID>
+
+# Check logs
+cat ~/singularity_sessions_slurm/logs/rstudio_sing_<JOB_ID>.err
+```
+
+## Troubleshooting
+
+**Can't connect?**
+- Check job is running: `squeue -u $USER`
+- Check logs: `cat ~/singularity_sessions_slurm/logs/*.err`
+- Make sure SSH tunnel is still open
+- Verify you're using the right compute node in your SSH command
+
+## Notes
+
+- CHEAHA uses Singularity to run containers
+- Apptainer is only needed locally if you want to build your own containers
+- R packages and VS Code settings persist between sessions
+- For large file transfers, use `rsync` instead of the SSH tunnel

--- a/containers/README.md
+++ b/containers/README.md
@@ -57,8 +57,8 @@ Open: http://localhost:8769
 
 - CHEAHA uses Singularity to run containers
 - Apptainer is only needed locally if you want to build custom containers
-- RStudio build details: see [containers/rstudio/README.md](/rstudio/README.md)
-- VS Code build details: see [containers/vscode/README.md](/vscode/README.md)
+- RStudio build details: see [containers/rstudio/README.md](./rstudio/README.md)
+- VS Code build details: see [containers/vscode/README.md](./vscode/README.md)
 
 ## Mounts (Quick)
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,159 +1,64 @@
 # Running RStudio & VS Code on CHEAHA
 
-Instructions for running RStudio Server and VS Code Server on CHEAHA using Singularity containers.
+Short overview and quick steps for running RStudio Server and VS Code Server on CHEAHA using Singularity containers.
 
-## What You Get
+## Overview
 
-- RStudio and VS Code running on compute nodes (not login nodes)
-- Access to your home directory, data storage, and lab projects
-- Persistent configurations and R libraries between sessions
-
-## Prerequisites
-
-- CHEAHA account with SSH access
-- SSH key configured for tunneling from your local machine
-
-## Quick Start
-
-### 1. Get the Container Images
-
-Pre-built containers are available at:
+- Runs on compute nodes (not login nodes)
+- Mounts your home, data, and project directories
+- Persistent settings between sessions
+- Pre-built containers live at:
 ```
 /data/project/worthey_lab/containers_temp
 ```
 
-Or build your own using Apptainer (locally) and transfer to CHEAHA:
-```bash
-# On your local machine (with Apptainer installed)
-apptainer build rstudio_custom.sif rstudio.def
+## Run Containers
 
-# Transfer to CHEAHA
-scp rstudio_custom.sif your_username@cheaha.rc.uab.edu:~/
-```
-
-**Note:** CHEAHA has Singularity for running containers. Apptainer is only needed locally if you want to build custom containers from `.def` files or pull from Docker.
-
-### 2. Set Up Directories (One-Time)
+### One-Time Setup
 
 ```bash
-mkdir -p ~/portable_rstudio_dirs/{etc/rstudio,home,run,tmp,var-lib,secure}
+mkdir -p ~/rstudio_base/{etc/rstudio,home,run,tmp,var-lib,secure}
 mkdir -p ~/code-server-base/{.config,.cache,home,run,tmp}
 mkdir -p ~/singularity_sessions_slurm/logs
-chmod 700 ~/portable_rstudio_dirs/secure
+chmod 700 ~/rstudio_base/secure
 ```
 
-### 3. Submit the Job
+### Run RStudio
 
 ```bash
 sbatch rstudio/run_rstudio_slurm.sh
-# or
-sbatch vscode/run_code_server_slurm.sh
-```
-
-Check which compute node it's running on:
-```bash
 squeue -u $USER
 ```
-Note the node name (e.g., `c0167`).
 
-### 4. Create SSH Tunnel (From Your Local Machine)
-
+Tunnel from your local machine (replace `your_username` and the node name):
 ```bash
-# For VS Code (port 8769)
-ssh -N -L 127.0.0.1:8769:127.0.0.1:8769 -J your_username@cheaha.rc.uab.edu your_username@c0167
-
-# For RStudio (port 8799)
 ssh -N -L 127.0.0.1:8799:127.0.0.1:8799 -J your_username@cheaha.rc.uab.edu your_username@c0167
 ```
 
-Replace:
-- `your_username` with your CHEAHA username
-- `c0167` with the compute node from step 3
+Open: http://localhost:8799
 
-Keep this terminal open.
-
-### 5. Open in Browser
-
-- **VS Code**: http://localhost:8769
-- **RStudio**: http://localhost:8799
-
-## What Gets Mounted
-
-### RStudio
-
-Inside RStudio, you'll find:
-- `~/cheaha_home` - your CHEAHA home directory
-- `~/cheaha_data` - your `/data/user/$USER` directory  
-- `~/nf1_rat_lw` - NF1 Rat Cohort project data
-
-### VS Code
-
-- `/mnt/cheaha_home` - your CHEAHA home directory
-- `/mnt/cheaha_data` - your `/data/user/$USER` directory
-- `/mnt/nf1_rat_lw` - NF1 Rat Cohort project data
-
-## Job Settings
-
-### RStudio
-- 8 CPUs, 32 GB RAM
-- 150 hours max runtime
-- Port 8799
-
-### VS Code  
-- 8 CPUs, 32 GB RAM
-- 8 hours max runtime
-- Port 8769
-
-Edit the SBATCH directives in the job scripts to change these.
-
-## Adding More Mounts
-
-Edit the `--bind` lines in your job script:
+### Run VS Code
 
 ```bash
---bind "/data/project/worthey_lab/projects/your_project:/home/$USER/my_project"
-```
-
-## R Packages
-
-R packages install to a persistent location automatically:
-
-```r
-install.packages("ggplot2")
-.libPaths()  # check where packages are stored
-```
-
-## Tools Included
-
-- samtools, bcftools, bedtools
-- CNVkit (in VS Code container via Micromamba)
-- HDF5, Arrow libraries
-- Standard compression tools
-
-## Managing Jobs
-
-```bash
-# Check running jobs
+sbatch vscode/run_code_server_slurm.sh
 squeue -u $USER
-
-# Cancel a job
-scancel <JOB_ID>
-
-# Check logs
-cat ~/singularity_sessions_slurm/logs/rstudio_sing_<JOB_ID>.err
 ```
 
-## Troubleshooting
+Tunnel from your local machine (replace `your_username` and the node name):
+```bash
+ssh -N -L 127.0.0.1:8769:127.0.0.1:8769 -J your_username@cheaha.rc.uab.edu your_username@c0167
+```
 
-**Can't connect?**
-- Check job is running: `squeue -u $USER`
-- Check logs: `cat ~/singularity_sessions_slurm/logs/*.err`
-- Make sure SSH tunnel is still open
-- Verify you're using the right compute node in your SSH command
+Open: http://localhost:8769
 
-## Notes
+## Build or Modify Containers
 
 - CHEAHA uses Singularity to run containers
-- Apptainer is only needed locally if you want to build your own containers
-- R packages and VS Code settings persist between sessions
-- For large file transfers, use `rsync` instead of the SSH tunnel
+- Apptainer is only needed locally if you want to build custom containers
+- RStudio build details: see [containers/rstudio/README.md](containers/rstudio/README.md)
+- VS Code build README will be added later
+
+## Mounts (Quick)
+
+- RStudio: `~/cheaha_home`, `~/cheaha_data`, `~/your_project`
+- VS Code: `/mnt/cheaha_home`, `/mnt/cheaha_data`, `/mnt/your_project`

--- a/containers/README.md
+++ b/containers/README.md
@@ -57,8 +57,8 @@ Open: http://localhost:8769
 
 - CHEAHA uses Singularity to run containers
 - Apptainer is only needed locally if you want to build custom containers
-- RStudio build details: see [containers/rstudio/README.md](containers/rstudio/README.md)
-- VS Code build details: see [containers/vscode/README.md](containers/vscode/README.md)
+- RStudio build details: see [containers/rstudio/README.md](/rstudio/README.md)
+- VS Code build details: see [containers/vscode/README.md](/vscode/README.md)
 
 ## Mounts (Quick)
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -14,6 +14,8 @@ Short overview and quick steps for running RStudio Server and VS Code Server on 
 
 ## Run Containers
 
+Note: the job scripts mount all projects under `/data/project/worthey_lab/projects` by default. Feel free to change that to your own project path before running.
+
 ### One-Time Setup
 
 ```bash
@@ -62,3 +64,12 @@ Open: http://localhost:8769
 
 - RStudio: `~/cheaha_home`, `~/cheaha_data`, `~/your_project`
 - VS Code: `/mnt/cheaha_home`, `/mnt/cheaha_data`, `/mnt/your_project`
+
+## Before You Exit
+
+- RStudio: close the project, then quit the session
+- VS Code: close the session before you exit
+
+## Browser Note
+
+`localhost` works fine in Chrome for me, but Firefox/DuckDuckGo are good alternatives if you run into cookie issues.

--- a/containers/README.md
+++ b/containers/README.md
@@ -62,8 +62,8 @@ Open: http://localhost:8769
 
 ## Mounts (Quick)
 
-- RStudio: `~/cheaha_home`, `~/cheaha_data`, `~/your_project`
-- VS Code: `/mnt/cheaha_home`, `/mnt/cheaha_data`, `/mnt/your_project`
+- RStudio: `~/cheaha_home`, `~/cheaha_data`, `~/worthey_lab_projects`
+- VS Code: `/mnt/cheaha_home`, `/mnt/cheaha_data`, `/mnt/worthey_lab_projects`
 
 ## Before You Exit
 
@@ -73,3 +73,11 @@ Open: http://localhost:8769
 ## Browser Note
 
 `localhost` works fine in Chrome for me, but Firefox/DuckDuckGo are good alternatives if you run into cookie issues.
+
+## Notes
+
+- For RStudio, you could mount directories to `/mnt/` like VS Code does, but I preferred having them at `/home/$USER/`. Makes it feel more native inside the container.
+- Both containers are persistent across sessions, so your settings and libraries stick around.
+- Change the `worthey_lab_projects` path in the job scripts to whatever you actually need before running.
+
+Last updated: February 10, 2026

--- a/containers/rstudio/README.md
+++ b/containers/rstudio/README.md
@@ -1,0 +1,34 @@
+# Building RStudio Container
+
+## Prerequisites
+
+- Apptainer installed on your local machine (Windows WSL2, Linux, or Mac)
+
+## Build
+
+```bash
+apptainer build rstudio_custom_4.4.2.sif rstudio.def
+```
+
+That gives you `rstudio_custom_4.4.2.sif` to transfer to CHEAHA.
+
+## What's Inside (Quick Flavor)
+
+This is not a plain RStudio image. It comes with a stack of tools I mostly use. I also built this while running PureCN, which needs CNVkit for one of its steps:
+- CNVkit (via Micromamba)
+- samtools, bcftools, bedtools, tabix
+- Python 3 with common scientific packages
+- Micromamba (so you can manage extra envs if needed)
+
+## Transfer to CHEAHA
+
+```bash
+scp rstudio_custom_4.4.2.sif your_username@cheaha.rc.uab.edu:~/
+```
+
+Or just grab it with Cyberduck/FileZilla if you prefer a UI.
+
+## Notes
+
+- I tested higher version tags (4.5), but Singularity/Apptainer on CHEAHA works well up to 4.4.2 right now
+- If CHEAHA updates their OS, this might change

--- a/containers/rstudio/README.md
+++ b/containers/rstudio/README.md
@@ -32,3 +32,5 @@ Or just grab it with Cyberduck/FileZilla if you prefer a UI.
 
 - I tested higher version tags (4.5), but Singularity/Apptainer on CHEAHA works well up to 4.4.2 right now
 - If CHEAHA updates their OS, this might change
+
+Last updated: February 10, 2026

--- a/containers/rstudio/rstudio.def
+++ b/containers/rstudio/rstudio.def
@@ -1,0 +1,114 @@
+Bootstrap: docker
+From: rocker/rstudio:4.4.2
+
+# RStudio Container Definition
+# For CHEAHA HPC at UAB
+# Build with: apptainer build rstudio_custom_4.4.2.sif rstudio.def
+
+%post
+  set -eux
+  
+  # Ensure apt sources exist (CHEAHA uses noble)
+  cat > /etc/apt/sources.list <<'EOF'
+deb http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu noble-updates main restricted universe multiverse
+deb http://archive.ubuntu.com/ubuntu noble-backports main restricted universe multiverse
+deb http://security.ubuntu.com/ubuntu noble-security main restricted universe multiverse
+EOF
+
+  apt-get update
+
+  # Core build toolchain
+  apt-get install -y --no-install-recommends \
+    pkgconf ca-certificates \
+    build-essential cmake ninja-build \
+    libssl-dev libxml2-dev \
+    zlib1g-dev libbz2-dev liblzma-dev \
+    libzstd-dev liblz4-dev libsnappy-dev libbrotli-dev
+
+  # Try t64 curl dev first (noble), fall back to non-t64
+  apt-get install -y --no-install-recommends libcurl4t64-openssl-dev || \
+    apt-get install -y --no-install-recommends libcurl4-openssl-dev
+
+  # Full build toolchain with gfortran
+  apt-get install -y --no-install-recommends \
+    build-essential gfortran pkg-config cmake ninja-build \
+    autoconf automake libtool make \
+    git curl wget ca-certificates \
+    perl python3 python3-pip
+
+  # Install micromamba for conda environments
+  mkdir -p /opt/micromamba/bin
+  curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest \
+    | tar -xvj -C /opt/micromamba/bin --strip-components=1 bin/micromamba
+
+  # Optional: Create CNVkit environment (bioinformatics)
+  /opt/micromamba/bin/micromamba create -y -p /opt/conda/envs/cnvkit \
+    -c conda-forge -c bioconda \
+    python=3.10 cnvkit "pandas<2" samtools bedtools bcftools tabix
+
+  /opt/micromamba/bin/micromamba clean -a -y
+
+  # Python scientific packages
+  apt-get install -y --no-install-recommends \
+    python3-numpy python3-scipy python3-matplotlib \
+    python3-reportlab \
+    python3-biopython python3-pyfaidx \
+    python3-pysam python3-venv
+
+  # Core R package development headers
+  apt-get install -y --no-install-recommends \
+    zlib1g-dev libbz2-dev liblzma-dev \
+    libcurl4-openssl-dev libssl-dev libxml2-dev \
+    libpng-dev libjpeg-dev libtiff-dev \
+    libreadline-dev
+
+  # Text rendering / graphics support
+  apt-get install -y --no-install-recommends \
+    libcairo2-dev libpango1.0-dev \
+    libharfbuzz-dev libfribidi-dev \
+    libfreetype6-dev libfontconfig1-dev
+
+  # Scientific computing libraries
+  apt-get install -y --no-install-recommends \
+    libicu-dev libffi-dev libsodium-dev \
+    libgmp-dev libmpfr-dev \
+    libopenblas-dev liblapack-dev
+
+  # Database connectivity
+  apt-get install -y --no-install-recommends \
+    libsqlite3-dev libpq-dev default-libmysqlclient-dev unixodbc-dev
+
+  # Arrow & compression codecs (for data processing)
+  apt-get install -y --no-install-recommends \
+    libsnappy-dev libzstd-dev liblz4-dev libbrotli-dev
+
+  # Optional JavaScript engine (some R packages)
+  apt-get install -y --no-install-recommends libv8-dev || true
+
+  # HDF5 & NetCDF (genomics, climate data)
+  apt-get install -y --no-install-recommends \
+    libhdf5-dev libnetcdf-dev
+
+  # Bioinformatics tools (for NF1 Rat project)
+  apt-get install -y --no-install-recommends \
+    libhts-dev samtools bcftools tabix bedtools
+
+  # Geospatial stack (sf, terra, units)
+  apt-get install -y --no-install-recommends \
+    libudunits2-dev libgdal-dev gdal-bin \
+    libgeos-dev libproj-dev proj-bin
+
+  # Java (for rJava, GATK, etc.)
+  apt-get install -y --no-install-recommends default-jdk || true
+
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
+
+%environment
+  # Make micromamba and conda environments available
+  export PATH="/opt/micromamba/bin:$PATH"
+  export MAMBA_ROOT_PREFIX=/opt/conda
+
+%runscript
+  exec "$@"

--- a/containers/rstudio/run_rstudio_slurm.sh
+++ b/containers/rstudio/run_rstudio_slurm.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+#SBATCH --job-name=rstudio_singularity
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --partition=amd-hdr100,intel-dcb,largemem,long
+#SBATCH --time=150:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+# See containers/README.md for usage details
+
+USER="$(whoami)"
+PORT=8799
+BASE="$HOME/rstudio_base"
+IMG="/data/project/worthey_lab/containers_temp/rstudio_custom_4.4.2.sif"
+
+mkdir -p "$BASE"/{etc/rstudio,home,run,tmp,var-lib,secure}
+chmod 700 "$BASE/secure"
+
+if [ ! -f "$BASE/secure/secure-cookie-key" ]; then
+  head -c 64 /dev/urandom | base64 > "$BASE/secure/secure-cookie-key"
+  chmod 600 "$BASE/secure/secure-cookie-key"
+fi
+
+mkdir -p "$BASE/home/R_libs"
+chmod 755 "$BASE/home/R_libs"
+
+cat > "$BASE/etc/rstudio/rserver.conf" <<EOF
+www-address=127.0.0.1
+www-port=$PORT
+auth-none=1
+secure-cookie-key-file=/home/$USER/secure/secure-cookie-key
+EOF
+
+mkdir -p "$BASE/home"/{cheaha_home,cheaha_data,worthey_lab_projects}
+
+cheaha_usr_home="/home/$USER"
+cheaha_usr_data="/data/user/$USER"
+worthey_lab_projects="/data/project/worthey_lab/projects/"  # replace with your own project path
+
+export SINGULARITYENV_R_LIBS_USER="/home/$USER/R_libs"
+
+unset R_LIBS R_LIBS_SITE R_HOME
+
+apptainer exec \
+  --bind "$BASE/home:/home/$USER" \
+  --bind "$BASE/run:/run" \
+  --bind "$BASE/tmp:/tmp" \
+  --bind "$BASE/var-lib:/var/lib/rstudio-server" \
+  --bind "$BASE/etc/rstudio:/etc/rstudio" \
+  --bind "$BASE/secure:/home/$USER/secure" \
+  --bind "$cheaha_usr_home:/home/$USER/cheaha_home" \
+  --bind "$cheaha_usr_data:/home/$USER/cheaha_data" \
+  --bind "$worthey_lab_projects:/home/$USER/worthey_lab_projects" \
+  "$IMG" \
+  /usr/lib/rstudio-server/bin/rserver \
+    --server-daemonize=0 \
+    --server-user="$USER"

--- a/containers/rstudio/run_rstudio_slurm.sh
+++ b/containers/rstudio/run_rstudio_slurm.sh
@@ -46,7 +46,7 @@ export SINGULARITYENV_R_LIBS_USER="/home/$USER/R_libs"
 
 unset R_LIBS R_LIBS_SITE R_HOME
 
-apptainer exec \
+singularity exec \
   --bind "$BASE/home:/home/$USER" \
   --bind "$BASE/run:/run" \
   --bind "$BASE/tmp:/tmp" \

--- a/containers/rstudio/run_rstudio_slurm.sh
+++ b/containers/rstudio/run_rstudio_slurm.sh
@@ -36,7 +36,7 @@ auth-none=1
 secure-cookie-key-file=/home/$USER/secure/secure-cookie-key
 EOF
 
-mkdir -p "$BASE/home"/{cheaha_home,cheaha_data,worthey_lab_projects}
+mkdir -p "$BASE/home"/{cheaha_home,cheaha_data,secure,worthey_lab_projects}
 
 cheaha_usr_home="/home/$USER"
 cheaha_usr_data="/data/user/$USER"

--- a/containers/vscode/README.md
+++ b/containers/vscode/README.md
@@ -23,3 +23,5 @@ scp code-server_4.108.2.sif your_username@cheaha.rc.uab.edu:~/
 ```
 
 Or just grab it with Cyberduck/FileZilla if you prefer a UI.
+
+Last updated: February 10, 2026

--- a/containers/vscode/README.md
+++ b/containers/vscode/README.md
@@ -7,7 +7,7 @@
 ## Build
 
 ```bash
-apptainer build code-server_4.108.2.sif code-server.def
+apptainer pull code-server_4.108.2.sif docker://codercom/code-server
 ```
 
 That gives you `code-server_4.108.2.sif` to transfer to CHEAHA.

--- a/containers/vscode/README.md
+++ b/containers/vscode/README.md
@@ -1,0 +1,25 @@
+# Building VS Code Container
+
+## Prerequisites
+
+- Apptainer installed on your local machine (Windows WSL2, Linux, or Mac)
+
+## Build
+
+```bash
+apptainer build code-server_4.108.2.sif code-server.def
+```
+
+That gives you `code-server_4.108.2.sif` to transfer to CHEAHA.
+
+## What's Inside
+
+Direct Docker pull of code-server version 4.108.2. Just VS Code Server, nothing extra.
+
+## Transfer to CHEAHA
+
+```bash
+scp code-server_4.108.2.sif your_username@cheaha.rc.uab.edu:~/
+```
+
+Or just grab it with Cyberduck/FileZilla if you prefer a UI.

--- a/containers/vscode/run_code_server_slurm.sh
+++ b/containers/vscode/run_code_server_slurm.sh
@@ -24,7 +24,7 @@ cheaha_usr_home="/home/$USER"
 cheaha_usr_data="/data/user/$USER"
 worthey_lab_projects="/data/project/worthey_lab/projects/"  # replace with your own project path
 
-apptainer exec \
+singularity exec \
   --bind "$BASE/home/:/home/$USER" \
   --bind "$BASE/.config:/home/$USER/.config" \
   --bind "$BASE/.cache:/home/$USER/.cache" \

--- a/containers/vscode/run_code_server_slurm.sh
+++ b/containers/vscode/run_code_server_slurm.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+#SBATCH --job-name=code-server_singularity
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --partition=amd-hdr100,intel-dcb,largemem,long,medium,short
+#SBATCH --time=8:00:00
+#SBATCH --output=%x_%j.out
+#SBATCH --error=%x_%j.err
+
+set -euo pipefail
+
+# See containers/README.md for usage details
+
+USER="$(whoami)"
+BASE="$HOME/code-server-base"
+IMG="/data/project/worthey_lab/containers_temp/code-server_4.108.2.sif"
+PORT=8769
+
+mkdir -p "$BASE"/{.config,.cache,home,run,tmp}
+
+cheaha_usr_home="/home/$USER"
+cheaha_usr_data="/data/user/$USER"
+worthey_lab_projects="/data/project/worthey_lab/projects/"  # replace with your own project path
+
+apptainer exec \
+  --bind "$BASE/home/:/home/$USER" \
+  --bind "$BASE/.config:/home/$USER/.config" \
+  --bind "$BASE/.cache:/home/$USER/.cache" \
+  --bind "$cheaha_usr_home:/mnt/cheaha_home" \
+  --bind "$cheaha_usr_data:/mnt/cheaha_data" \
+  --bind "$worthey_lab_projects:/mnt/worthey_lab_projects" \
+  "${IMG}" \
+  code-server --bind-addr="127.0.0.1:${PORT}" --auth=none


### PR DESCRIPTION
Added containers directory at root. 

Please review:
1. README at containers/README.md for instructions to run containers
2. Sub-directories rstudio and vscode for job scripts
3. Recipe instructions to build containers locally using apptainer
4. A central location to store containers that the group can use. Currently, I created a directory `/data/project/worthey_lab/containers_temp`